### PR TITLE
Use reconnect-net instead of reconnect

### DIFF
--- a/lib/gearman.coffee
+++ b/lib/gearman.coffee
@@ -17,7 +17,7 @@
 EventEmitter = require("events").EventEmitter
 _ = require 'underscore'
 assert = require 'assert'
-reconnect = require 'reconnect'
+reconnect = require 'reconnect-net'
 nextTick = require('timers').setImmediate or process.nextTick
 
 uid = 0

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "node": ">= 0.6.x"
   },
   "dependencies": {
-    "underscore": "~1.5.2",
     "async": "~0.1.22",
-    "reconnect": "~1.5.2"
+    "underscore": "~1.5.2",
+    "reconnect-net": "0.0.0"
   },
   "devDependencies": {
     "coffee-errors": "~0.8.6",


### PR DESCRIPTION
We had problems installing all the dependencies for reconnect module on
one of our boxes (32-bit vanilla Ubuntu Trusty using npm 1.3). This
patch replaces reconnect with reconnect-net that doesn't depend on
sockjs or engine.io which are unneeded with gearman-coffee.
