### PR TITLE
worker: shutdown gracefully even if no gearman connection

### DIFF
--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -138,7 +138,7 @@ class Worker extends Gearman
     # poll until the running job is complete and
     # all data is written to the socket
     async.whilst(
-      => @socket.bufferSize > 0 or @work_in_progress
+      => @socket?.bufferSize > 0 or @work_in_progress
       (cb) -> setTimeout cb, 1000
       done
     )


### PR DESCRIPTION
- previously got error: Cannot read property 'bufferSize' of undefined
- this occurred when failed to connect to the gearman machine
