### PR TITLE
Improve testing environment for gearman-coffee

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test-cov: build
 	COV_GEARMAN=1 node_modules/mocha/bin/mocha -R html-cov --compilers coffee:coffee-script test/{test,test-raceconditions}.coffee | tee coverage.html
 	open coverage.html
 
-$(TESTS):
+$(TESTS): build
 	@if [[ -z "$(DRONE)" ]]; then \
 		./reset_gearmand.sh; \
 	fi

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "coffee-errors": "~0.8.6",
     "coffee-script": "~1.6.3",
-    "mocha": "~1.2.2"
+    "mocha": "~1.6.0"
   },
   "scripts": {
     "test": "make -B test"


### PR DESCRIPTION
I upgrade to mocha 1.6 so we could get support for "only". I updated the
Makefile because not building the code before 'make <testfile>' was
confusing.
