### PR TITLE
fix mock job ordering

### DIFF
--- a/lib/mocks/jobs.coffee
+++ b/lib/mocks/jobs.coffee
@@ -12,15 +12,25 @@ class MockJob extends EventEmitter
   intervalEmit: (event, timeout, data) ->
     interval = Math.floor timeout / (data.length + 1)
     @delayEmit event, (i + 1) * interval, el for el, i in data
+  # Takes a list of events and returns a new list of events sorted in increasing order, with each
+  # timeout being the offset from the previous event, such that the total offset for the event is
+  # the same.
+  @orderEvents: (events) ->
+    return events unless events.length > 1
+    events = _(events).sortBy 'timeout'
+    # Pair each event with the previous event, except for the first which gets paired with 0
+    pairs = _.zip events, [timeout: 0].concat _.first(events, events.length - 1)
+    _.map pairs, ([curr, prev]) ->
+      _.extend {}, curr, timeout: curr.timeout - prev.timeout
   start: =>
-    events =
-      if @events.length < 2
-        @events
-      else
-        events = _.sortBy @events, (e) -> e.timeout
-        event_pairs = _.zip events, _.rest(events).concat [_.last events]
-        _.map event_pairs, ([event, next_event]) ->
-          _.extend event, timeout: next_event.timeout - event.timeout
+    # We can't just set timeouts for all of the events because it may not result in a predictable
+    # order. For instance, consider:
+    # a 'complete' event is registered after 100ms
+    # a 'created' event is registered after 10ms
+    # If something then blocks the event loop for 110ms, both will fire on the next tick, in the
+    # order that they were registered, so we'd see the 'complete' event before seeing the 'create'
+    # event.
+    events = @constructor.orderEvents @events
     async.forEachSeries events, ({event, timeout, args}, cb_fe) =>
       setTimeout =>
         @emit event, @handle, args...

--- a/test/mocks.coffee
+++ b/test/mocks.coffee
@@ -1,0 +1,27 @@
+_         = require 'underscore'
+assert    = require 'assert'
+{MockJob} = require('../lib/mocks').Jobs
+
+describe 'mocks', ->
+  describe 'jobs', ->
+    describe 'event ordering', ->
+      make_events = (arr) -> _(arr).map (el) -> timeout: el
+      _.each [
+        in: [1, 1500, 0]
+        out: [0, 1, 1499]
+        name: 'with three events'
+      ,
+        in: [1]
+        out: [1]
+        name: 'with one event'
+      ,
+        in: []
+        out: []
+        name: 'with no events'
+      ,
+        in: [0, 2, 10, 50]
+        out: [0, 2, 8, 40]
+        name: 'with four events'
+      ], (spec) ->
+        it spec.name, ->
+          assert.deepEqual MockJob.orderEvents(make_events spec.in), make_events spec.out


### PR DESCRIPTION
The old logic for how to order jobs was wrong. Given a list of timeouts `[1, 1500, 0]`, it would produce as output `[1, 1499, 0]`, when expected is `[0, 1, 1499]`.

I've also added a comment for why that complex logic exists (which was added in https://github.com/Clever/gearman-node/pull/9), but I'm not sure if it's right - @jonahkagan, do you remember why you needed to add that?